### PR TITLE
dependencies: don't need oppo_common anymore

### DIFF
--- a/cm.dependencies
+++ b/cm.dependencies
@@ -1,9 +1,5 @@
 [
   {
-    "repository": "android_device_oppo_common",
-    "target_path": "device/oppo/common"
-  },
-  {
     "repository": "android_kernel_oneplus_msm8974",
     "target_path": "kernel/oneplus/msm8974"
   }


### PR DESCRIPTION
With reference to commit : ee86bf77a418e53cd210c1e757b075197976cffa
We have detached from oppo and don't need to sync it anymore

Change-Id: Ifd1724780fbee02a79fb208c450e2edd1adb8198
